### PR TITLE
flickr thumbnails

### DIFF
--- a/extensions/flickr/extension.inc.php
+++ b/extensions/flickr/extension.inc.php
@@ -26,6 +26,7 @@ class Lifestream_FlickrFeed extends Lifestream_PhotoFeed
 	function yield($row, $url, $key)
 	{
 		$data = parent::yield($row, $url, $key);
+		$data['thumbnail'] = str_replace('_m', '_t', $data['image']);
 		$data['image'] = str_replace('_m', '', $data['image']);
 		return $data;
 	}


### PR DESCRIPTION
I was having an issue with Flickr not displaying thumbnails on my install.  This patch stores the Flickr thumbnail url in the 'thumbnail' field so it can be displayed when the stream is rendered.
