### PR TITLE
Updated YouTube feed URLs and fixed icon paths on Windows

### DIFF
--- a/extensions/youtube/extension.inc.php
+++ b/extensions/youtube/extension.inc.php
@@ -27,7 +27,7 @@ class Lifestream_YouTubeFeed extends Lifestream_PhotoFeed
 	
 	function get_public_url()
 	{
-		return 'http://www.youtube.com/user/'.$this->get_option('username');
+		return 'http://gdata.youtube.com/feeds/base/users/'.$this->get_option('username').'/favorites';
 	}
 	
 	function get_label_class($key)
@@ -39,7 +39,7 @@ class Lifestream_YouTubeFeed extends Lifestream_PhotoFeed
 
 	function get_posted_url()
 	{
-		return 'http://gdata.youtube.com/feeds/api/users/'.$this->get_option('username').'/uploads?v=2';
+		return 'http://gdata.youtube.com/feeds/base/users/'.$this->get_option('username').'/uploads';
 	}
 
 	function get_favorited_url()
@@ -60,9 +60,9 @@ class Lifestream_YouTubeFeed extends Lifestream_PhotoFeed
 		$data = parent::yield($row, $url, $key);
 		
 		$data['image'] = str_replace('_m', '', $data['image']);
-
-		$enclosure = $row->get_enclosure();
-		$data['player_url'] = $enclosure->get_link();
+		
+		/*$enclosure = $row->get_enclosure();
+		$data['player_url'] = $enclosure->get_link();*/
 		return $data;
 	}
 	

--- a/inc/core.php
+++ b/inc/core.php
@@ -439,7 +439,8 @@ class Lifestream
 	
 	function get_absolute_media_url($path)
 	{
-		$path = str_replace(trailingslashit(WP_CONTENT_DIR), '', $path);
+		$path = str_replace('\\', '/', $path);
+		$path = str_replace(trailingslashit(str_replace('\\', '/', WP_CONTENT_DIR)), '', $path);
 		$path = str_replace(trailingslashit(realpath(LIFESTREAM_PATH)), 'plugins/'.LIFESTREAM_PLUGIN_DIR.'/', $path);
 		return str_replace('\\', '/', trailingslashit(WP_CONTENT_URL).$path);
 	}


### PR DESCRIPTION
- In my local install on Windows 7 & WAMP, feed icon URLs were not being constructed properly due to slash/backslash issues.
- YouTube has changed the location of its feeds.
